### PR TITLE
The handler instructs the service on how to update connection direction

### DIFF
--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -113,7 +113,7 @@ pub enum HandlerOut {
     /// A session is only considered established once we have received a signed ENR from the
     /// node and either the observed `SocketAddr` matches the one declared in the ENR or the
     /// ENR declares no `SocketAddr`.
-    Established(Enr, SocketAddr, ConnectionDirectionInstruction),
+    Established(Enr, SocketAddr, ConnectionUpdate),
 
     /// A Request has been received from a node on the network.
     Request(NodeAddress, Box<Request>),
@@ -142,7 +142,7 @@ pub enum ConnectionDirection {
 
 /// An instruction from the handler to the service how to update the connection direction.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ConnectionDirectionInstruction {
+pub enum ConnectionUpdate {
     /// Incoming.
     Incoming,
     /// Outgoing.
@@ -708,13 +708,11 @@ impl Handler {
                 // outgoing session is that we originally sent a RANDOM packet (signifying we did
                 // not have a session for a request) and the packet is not a PING (we are not
                 // trying to update an old session that may have expired.
-                let connection_direction_instruction = {
+                let connection_update = {
                     match (request_call.initiating_session(), &request_call.body()) {
-                        (true, RequestBody::Ping { .. }) => {
-                            ConnectionDirectionInstruction::Incoming
-                        }
-                        (true, _) => ConnectionDirectionInstruction::Outgoing,
-                        (false, _) => ConnectionDirectionInstruction::IncomingIfNotExists,
+                        (true, RequestBody::Ping { .. }) => ConnectionUpdate::Incoming,
+                        (true, _) => ConnectionUpdate::Outgoing,
+                        (false, _) => ConnectionUpdate::IncomingIfNotExists,
                     }
                 };
 
@@ -733,7 +731,7 @@ impl Handler {
                     .send(HandlerOut::Established(
                         enr,
                         node_address.socket_addr,
-                        connection_direction_instruction,
+                        connection_update,
                     ))
                     .await
                     .unwrap_or_else(|e| warn!("Error with sending channel: {}", e));
@@ -823,7 +821,7 @@ impl Handler {
                             .send(HandlerOut::Established(
                                 enr,
                                 node_address.socket_addr,
-                                ConnectionDirectionInstruction::Incoming,
+                                ConnectionUpdate::Incoming,
                             ))
                             .await
                         {
@@ -1035,7 +1033,7 @@ impl Handler {
                                                 .send(HandlerOut::Established(
                                                     enr,
                                                     node_address.socket_addr,
-                                                    ConnectionDirectionInstruction::Outgoing,
+                                                    ConnectionUpdate::Outgoing,
                                                 ))
                                                 .await
                                             {

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -710,7 +710,9 @@ impl Handler {
                 // trying to update an old session that may have expired.
                 let connection_direction_instruction = {
                     match (request_call.initiating_session(), &request_call.body()) {
-                        (true, RequestBody::Ping { .. }) => ConnectionDirectionInstruction::Incoming,
+                        (true, RequestBody::Ping { .. }) => {
+                            ConnectionDirectionInstruction::Incoming
+                        }
                         (true, _) => ConnectionDirectionInstruction::Outgoing,
                         (false, _) => ConnectionDirectionInstruction::IncomingIfNotExists,
                     }

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -113,7 +113,7 @@ pub enum HandlerOut {
     /// A session is only considered established once we have received a signed ENR from the
     /// node and either the observed `SocketAddr` matches the one declared in the ENR or the
     /// ENR declares no `SocketAddr`.
-    Established(Enr, SocketAddr, ConnectionDirection),
+    Established(Enr, SocketAddr, ConnectionDirectionInstruction),
 
     /// A Request has been received from a node on the network.
     Request(NodeAddress, Box<Request>),
@@ -138,6 +138,17 @@ pub enum ConnectionDirection {
     Incoming,
     /// We contacted the node.
     Outgoing,
+}
+
+/// An instruction from the handler to the service how to update the connection direction.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ConnectionDirectionInstruction {
+    /// Incoming.
+    Incoming,
+    /// Outgoing.
+    Outgoing,
+    /// If there is an established connection keep it; if not Incoming.
+    IncomingIfNotExists,
 }
 
 /// A reference for the application layer to send back when the handler requests any known
@@ -697,11 +708,11 @@ impl Handler {
                 // outgoing session is that we originally sent a RANDOM packet (signifying we did
                 // not have a session for a request) and the packet is not a PING (we are not
                 // trying to update an old session that may have expired.
-                let connection_direction = {
+                let connection_direction_instruction = {
                     match (request_call.initiating_session(), &request_call.body()) {
-                        (true, RequestBody::Ping { .. }) => ConnectionDirection::Incoming,
-                        (true, _) => ConnectionDirection::Outgoing,
-                        (false, _) => ConnectionDirection::Incoming,
+                        (true, RequestBody::Ping { .. }) => ConnectionDirectionInstruction::Incoming,
+                        (true, _) => ConnectionDirectionInstruction::Outgoing,
+                        (false, _) => ConnectionDirectionInstruction::IncomingIfNotExists,
                     }
                 };
 
@@ -720,7 +731,7 @@ impl Handler {
                     .send(HandlerOut::Established(
                         enr,
                         node_address.socket_addr,
-                        connection_direction,
+                        connection_direction_instruction,
                     ))
                     .await
                     .unwrap_or_else(|e| warn!("Error with sending channel: {}", e));
@@ -810,7 +821,7 @@ impl Handler {
                             .send(HandlerOut::Established(
                                 enr,
                                 node_address.socket_addr,
-                                ConnectionDirection::Incoming,
+                                ConnectionDirectionInstruction::Incoming,
                             ))
                             .await
                         {
@@ -1022,7 +1033,7 @@ impl Handler {
                                                 .send(HandlerOut::Established(
                                                     enr,
                                                     node_address.socket_addr,
-                                                    ConnectionDirection::Outgoing,
+                                                    ConnectionDirectionInstruction::Outgoing,
                                                 ))
                                                 .await
                                             {

--- a/src/service.rs
+++ b/src/service.rs
@@ -1370,7 +1370,11 @@ impl Service {
 
     /// The equivalent of libp2p `inject_connected()` for a udp session. We have no stream, but a
     /// session key-pair has been negotiated.
-    fn inject_session_established(&mut self, enr: Enr, direction_instruction: ConnectionDirectionInstruction) {
+    fn inject_session_established(
+        &mut self,
+        enr: Enr,
+        direction_instruction: ConnectionDirectionInstruction,
+    ) {
         // Ignore sessions with non-contactable ENRs
         if self.ip_mode.get_contactable_addr(&enr).is_none() {
             return;
@@ -1384,7 +1388,7 @@ impl Service {
             ConnectionDirectionInstruction::IncomingIfNotExists => {
                 let key = kbucket::Key::from(node_id.clone());
                 match self.kbuckets.write().entry(&key) {
-                    Entry::Present(_, status) if status.is_connected() => { status.direction }
+                    Entry::Present(_, status) if status.is_connected() => status.direction,
                     _ => ConnectionDirection::Incoming,
                 }
             }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1384,7 +1384,7 @@ impl Service {
             ConnectionDirectionInstruction::Incoming => ConnectionDirection::Incoming,
             ConnectionDirectionInstruction::Outgoing => ConnectionDirection::Outgoing,
             ConnectionDirectionInstruction::IncomingIfNotExists => {
-                let key = kbucket::Key::from(node_id.clone());
+                let key = kbucket::Key::from(node_id);
                 match self.kbuckets.write().entry(&key) {
                     Entry::Present(_, status) if status.is_connected() => status.direction,
                     _ => ConnectionDirection::Incoming,

--- a/src/service.rs
+++ b/src/service.rs
@@ -164,9 +164,7 @@ pub enum ServiceRequest {
     RequestEventStream(oneshot::Sender<mpsc::Receiver<Discv5Event>>),
 }
 
-use crate::discv5::PERMIT_BAN_LIST;
-use crate::handler::ConnectionDirectionInstruction;
-use crate::kbucket::Entry;
+use crate::{discv5::PERMIT_BAN_LIST, handler::ConnectionDirectionInstruction, kbucket::Entry};
 
 pub struct Service {
     /// Configuration parameters.

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -178,7 +178,7 @@ async fn test_updating_connection_direction_on_new_session() {
         .unwrap();
 
     let enr_key2 = CombinedKey::generate_secp256k1();
-    let ip2 = "127.0.0.1".parse().unwrap();
+    let ip2 = std::net::Ipv4Addr::LOCALHOST;
     let enr2 = EnrBuilder::new("v4")
         .ip4(ip2)
         .udp4(10002)

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -170,7 +170,7 @@ async fn test_updating_connection_direction_on_new_session() {
     init();
 
     let enr_key1 = CombinedKey::generate_secp256k1();
-    let ip = "127.0.0.1".parse().unwrap();
+    let ip = std::net::Ipv4Addr::LOCALHOST;
     let enr = EnrBuilder::new("v4")
         .ip4(ip)
         .udp4(10001)

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -193,31 +193,25 @@ async fn test_updating_connection_direction_on_new_session() {
     .await;
 
     // None -> Incoming
-    service.inject_session_established(
-        enr2.clone(),
-        ConnectionDirectionInstruction::IncomingIfNotExists,
-    );
+    service.inject_session_established(enr2.clone(), ConnectionUpdate::IncomingIfNotExists);
     let status = service.kbuckets.read().iter_ref().next().unwrap().status;
     assert!(status.is_connected());
     assert_eq!(ConnectionDirection::Incoming, status.direction);
 
     // Incoming -> Outgoing
-    service.inject_session_established(enr2.clone(), ConnectionDirectionInstruction::Outgoing);
+    service.inject_session_established(enr2.clone(), ConnectionUpdate::Outgoing);
     let status = service.kbuckets.read().iter_ref().next().unwrap().status;
     assert!(status.is_connected());
     assert_eq!(ConnectionDirection::Outgoing, status.direction);
 
     // Outgoing -> Outgoing (no changes as the outgoing connection exists)
-    service.inject_session_established(
-        enr2.clone(),
-        ConnectionDirectionInstruction::IncomingIfNotExists,
-    );
+    service.inject_session_established(enr2.clone(), ConnectionUpdate::IncomingIfNotExists);
     let status = service.kbuckets.read().iter_ref().next().unwrap().status;
     assert!(status.is_connected());
     assert_eq!(ConnectionDirection::Outgoing, status.direction);
 
     // Outgoing -> Incoming
-    service.inject_session_established(enr2, ConnectionDirectionInstruction::Incoming);
+    service.inject_session_established(enr2, ConnectionUpdate::Incoming);
     let status = service.kbuckets.read().iter_ref().next().unwrap().status;
     assert!(status.is_connected());
     assert_eq!(ConnectionDirection::Incoming, status.direction);


### PR DESCRIPTION
## Description

<!--
A summary of what this pull request achieves and a rough list of changes.
-->

Base branch (pull request): https://github.com/sigp/discv5/pull/184




A connection direction can unexpectedly change from Outgoing to Incoming in the scenario shown in [this diagram.](https://github.com/sigp/discv5/pull/184#issuecomment-1562032339)

This PR modifies the handler to give `ConnectionDirectionInstruction` to the service instead of `ConnectionDirection` so that we can keep an existing connection direction.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR. Feel free to remove this section if it's unnecessary 
-->

## Change checklist

- [ ] Self-review
- [ ] Documentation updates if relevant
- [ ] Tests if relevant
